### PR TITLE
Use github's default Node version for all the CI actions

### DIFF
--- a/.github/workflows/cross_browser_e2e_test.yml
+++ b/.github/workflows/cross_browser_e2e_test.yml
@@ -10,9 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: lts/*
+    - name: Use default Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers

--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -17,7 +17,7 @@ jobs:
       run: |-
         npm run lint
   test:
-    name: test
+    name: unit test
     runs-on:
       - ubuntu-latest
     steps:

--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -1,49 +1,33 @@
----
 name: lint and unit test
 on:
   push:
-
 jobs:
   lint:
     name: lint
-    runs-on:
-      - ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: ['20.x', '22.x']
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use default Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: ${{ matrix.node-version }}
         cache: npm
-
     - name: Install dependencies
       run: npm ci
-
     - name: npm run lint
       run: |-
         npm run lint
-
   test:
     name: test
     runs-on:
       - ubuntu-latest
-
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use default Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: ${{ matrix.node-version }}
         cache: npm
-
     - name: Install dependencies
       run: npm ci
-
     - name: npm run test
       run: |-
         npm run test

--- a/.github/workflows/validate_build.yml
+++ b/.github/workflows/validate_build.yml
@@ -6,9 +6,8 @@ on:
     branches: [ main ]
 jobs:
   validate_build:
-    name: validate_build
-    runs-on:
-      - ubuntu-latest
+    name: validate build
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Use default Node.js

--- a/.github/workflows/validate_build.yml
+++ b/.github/workflows/validate_build.yml
@@ -11,23 +11,18 @@ jobs:
       - ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Use Node.js latest
+    - name: Use default Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: lts/*
         cache: npm
-
     - name: Install dependencies
       run: npm ci
-
     - name: Build and verify MAJC dist files
       run: |-
         npm run build
-
     - name: Install React Example dependencies
       run: npm ci
       working-directory: ./examples/react
-
     - name: Build and verify Example React App
       run: npm run build
       working-directory: ./examples/react


### PR DESCRIPTION
## Problem Statement

We're currently running some of our CI steps with the matrix strategy, which tells github to run multiple versions of our checks using different Nodes. However, since our code runs in the browser, the version of Node doesn't matter outside of the local dev environment, so we should save time and resources by cleaning this up.

## Proposed Changes

Remove the matrix strategy, the multiple nodes, and any specific reference to Node. Also standardize the spacing in our github workflow yamls.

## Verification Steps

- [ ] Please make sure formatting is consistent throughout the workflow yaml files
- [ ] Please take a look at the workflow runs on this PR and make sure everything is still running as expected

