### PR TITLE
[MAJC-130] Set up Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## References

[MAJC-130](https://mozilla-hub.atlassian.net/browse/MAJC-130)

## Problem Statement

We're getting ready to pin our `package.json`'s dependencies to specific version. We need a way to get automatically notified when those dependencies have new updates. Let's try using dependabot for that as well.

## Proposed Changes

Add a `dependabot.yml` which will configure it to check on our dependencies weekly for updates.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates

## Verification Steps

- [ ] Not sure if this can be verified before merge, but maybe you can think of something? Otherwise let's give it a try!