### PR TITLE
[MAJC-130] Restrict permissions for github actions workflows

### DIFF
--- a/.github/workflows/cross_browser_e2e_test.yml
+++ b/.github/workflows/cross_browser_e2e_test.yml
@@ -1,4 +1,7 @@
 name: cross browser e2e test
+permissions:
+  contents: read
+  pull-requests: write
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -1,4 +1,7 @@
 name: lint and unit test
+permissions:
+  contents: read
+  pull-requests: write
 on:
   push:
 jobs:

--- a/.github/workflows/validate_build.yml
+++ b/.github/workflows/validate_build.yml
@@ -1,4 +1,7 @@
 name: validate build
+permissions:
+  contents: read
+  pull-requests: write
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
## References

[MAJC-130](https://mozilla-hub.atlassian.net/browse/MAJC-130)

## Problem Statement

Address [CodeQL scan results](https://github.com/mozilla-services/majc/security/code-scanning/9) results that noticed we have unrestricted workflow permissions. 

## Proposed Changes

"Practice the Principle of Least Privilege" and give the github action's token the least possible permissions in the repo when running actions. It's also recommended generally in the [guide to hardening Github actions](https://docs.github.com/en/enterprise-cloud@latest/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#restricting-permissions-for-tokens), and we got 0/10 on this metric from the OSSF scorecard.

## Verification Steps

- [ ] Take a look at the diff and actions runs and make sure everything looks good there
