### PR TITLE
[MAJC-71] Fix workflow trigger for publishing releases

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -2,6 +2,9 @@
 name: Publish to npm
 on:
   push:
+    branches:
+      - main
+
     tags:
       - v.[0-9]+rc[0-9]+
 


### PR DESCRIPTION
## References

[MAJC-71](https://mozilla-hub.atlassian.net/browse/MAJC-71)

## Problem Statement

Whoops, looks like when changing from the test branch to the actual trigger I removed too much and pushing a tag didn't kick off the release workflow.

## Proposed Changes

Add back the branch specification to trigger the publish workflow when tags are pushed to `main`. This is exactly what we have for Shepherd so it should work this time. 🤞 

## Verification Steps

YOLO
