### PR TITLE
[MAJC-71] Fix workflow trigger for publishing releases, one more time

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -3,7 +3,7 @@ name: Publish to npm
 on:
   push:
     tags:
-      - v.[0-9]+rc[0-9]+
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:

--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -2,9 +2,6 @@
 name: Publish to npm
 on:
   push:
-    branches:
-      - main
-
     tags:
       - v.[0-9]+rc[0-9]+
 


### PR DESCRIPTION
## References

[MAJC-71](https://mozilla-hub.atlassian.net/browse/MAJC-71)

## Problem Statement

So [that last attempt triggered on all pushes to `main`](https://github.com/mozilla-services/majc/actions/workflows/publish_to_npm.yml), not just pushes of version tags, which we don't want. Third time's the charm, I think we got it this time. 

## Proposed Changes

Just trigger on tags pushed, not on pushes to the `main` branch 🤦‍♀️ 

## Verification Steps

Take a good close look at the workflow trigger and lmk I'm not crazy this time.
