### PR TITLE
fix: remove automatic addition of dist directory in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
 npm run build:production
-git add dist/.


### PR DESCRIPTION
I realized there is a pre-commit hook that tries to add the dist folder to the commit. Since we don't commit `/dist` folder anymore this is not needed.