### PR TITLE
chore(deps): bump uuid to 14 + @hey-api/client-fetch to 0.13

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -23,8 +23,20 @@ export default {
   testEnvironment: "jsdom",
   testPathIgnorePatterns: ["examples/tests"],
   transform: {
-    "^.+.(ts|tsx)?$": ["ts-jest", {}],
+    "^.+\\.(ts|tsx)$": ["ts-jest", {}],
+    "^.+\\.js$": ["ts-jest", {
+      useESM: false,
+      tsconfig: {
+        allowJs: true,
+        module: "commonjs",
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+      },
+    }],
   },
+  transformIgnorePatterns: [
+    "node_modules/(?!uuid/)",
+  ],
   moduleNameMapper: {
     "@/jest.setup": ["<rootDir>/jest.setup.ts"],
     "@/package.json": ["<rootDir>/package.json"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.10",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hey-api/client-fetch": "0.12.0",
-        "uuid": "11.1.0"
+        "@hey-api/client-fetch": "0.13.1",
+        "uuid": "14.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1368,9 +1368,10 @@
       }
     },
     "node_modules/@hey-api/client-fetch": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/client-fetch/-/client-fetch-0.12.0.tgz",
-      "integrity": "sha512-/iZ6dhs39N0kjzCa9tlNeLNufVUd8zzv/wI1ewQt5AEHaVuDnAxvuQT+fRIPYkfIWKR3gVZKRp5mcCo29voYzQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/client-fetch/-/client-fetch-0.13.1.tgz",
+      "integrity": "sha512-29jBRYNdxVGlx5oewFgOrkulZckpIpBIRHth3uHFn1PrL2ucMy52FvWOY3U3dVx2go1Z3kUmMi6lr07iOpUqqA==",
+      "deprecated": "Starting with v0.73.0, this package is bundled directly inside @hey-api/openapi-ts.",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
@@ -10628,16 +10629,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     }
   },
   "dependencies": {
-    "@hey-api/client-fetch": "0.12.0",
-    "uuid": "11.1.0"
+    "@hey-api/client-fetch": "0.13.1",
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
## Summary

- Bumps `uuid` 11.1.0 → 14.0.0 and `@hey-api/client-fetch` 0.12.0 → 0.13.1 — the same prod-deps that dependabot proposed in #157 and #170.
- Fixes the Jest config so it can resolve uuid, which has been ESM-only since v12.

## Why the jest change is needed

uuid v12 dropped its CommonJS build. With the old config, ts-jest would only transform `.ts`/`.tsx`, and Jest's default `transformIgnorePatterns` ignores all of `node_modules/`. So when a test imported `uuid`, Jest tried to `require()` ESM and choked on `export { … }`.

The fix:
- Add a transform entry for `.js` files using `ts-jest` with `allowJs: true` and `module: commonjs`.
- Exempt `uuid` from `transformIgnorePatterns` so its ESM gets transformed for the test environment.

The project's own source is `.ts`/`.tsx` so the new JS transform only kicks in for the uuid files exempted from `transformIgnorePatterns`.

## Supersedes

- Closes #170 (uuid bump alone, was failing tests for this reason)
- Closes #157 (production-deps group, same uuid problem)

## Test plan

- [x] `npm test` — 20/20 suites pass, 102/102 tests pass, 100% statement coverage
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds, validates dist
- [ ] CI: cross-browser e2e