### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mozilla/majc",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mozilla/majc",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MPL-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla/majc",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mozilla-services/majc.git"


### PR DESCRIPTION
## Summary

Follow-up to the v0.1.10 npm release. Bumps `package.json` (and lockfile) to `0.1.11` so main reflects the next development cycle, matching the pattern of #148 (0.1.9) and #151 (0.1.10).

No code changes.